### PR TITLE
增加对自动黑暗模式支持

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ ${contentList.join('\n')}
 
 const getModifyVars = (theme = 'light', modifyVars, disableExtendsDark) => {
   try {
-    if (theme === 'dark') {
+    if (theme === 'dark' || theme === 'auto') {
       return {
         ...(disableExtendsDark ? {} : darkTheme),
         ...modifyVars,
@@ -244,8 +244,10 @@ const renderLess = async (
         javascriptEnabled: true,
         filename: path.resolve(proLess),
       })
+      .then(out => out.css)
+      .then(out => theme === 'auto' ? '@media (prefers-color-scheme: dark) {' + out + 'body{background-color: #000;}}' : out)
       // 如果需要压缩，再打开压缩功能默认打开
-      .then(out => (min ? uglifycss.processString(out.css) : out.css))
+      .then(out => (min ? uglifycss.processString(out) : out))
       .catch(e => {
         console.log(e);
       })


### PR DESCRIPTION
当前主题生成只有两种类型：明亮主题（`light`）和黑暗主题（`dark`）。现在越来越多网站支持了自动明暗主题。

这个PR给提供了一种新的主题类型：自动明暗主题（`auto`）。

使用者在配置中设置`theme`属性为`auto`，即可生成自动明暗主题。

例如：
```json
{
  "theme": [
    {
      "key": "red",
      "fileName": "red-light.css",
      "modifyVars": {
        "@primary-color": "red"
      }
    },
    {
      "key": "red",
      "theme": "dark",
      "fileName": "red-dark.css",
      "modifyVars": {
        "@primary-color": "red"
      }
    },
    {
      "key": "red",
      "theme": "auto",
      "fileName": "red-auto.css",
      "modifyVars": {
        "@primary-color": "red"
      }
    }
  ]
}
```

原理是在黑暗主题基础上增加了Media Query条件：`@media (prefers-color-scheme: dark) `

